### PR TITLE
Rework GUI daemon to not reveal monitor size, window positions and avoid input stealng

### DIFF
--- a/gui-daemon/Makefile
+++ b/gui-daemon/Makefile
@@ -35,6 +35,7 @@ qubes-guid: $(OBJS)
 		`pkg-config --libs vchan-$(BACKEND_VMM)` \
 		`pkg-config --libs libpng` \
 		`pkg-config --libs libconfig` \
-		`pkg-config --libs libnotify`
+		`pkg-config --libs libnotify` \
+		`pkg-config --libs xrandr`
 clean:
 	rm -f qubes-guid *.o *~

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -143,6 +143,7 @@ struct _global_handles {
 	Atom wm_state_fullscreen; /* Atom: _NET_WM_STATE_FULLSCREEN */
 	Atom wm_state_demands_attention; /* Atom: _NET_WM_STATE_DEMANDS_ATTENTION */
 	Atom wm_state_hidden;	/* Atom: _NET_WM_STATE_HIDDEN */
+	Atom wm_user_time;  /* Atom: _NET_WM_USER_TIME */
 	Atom frame_extents; /* Atom: _NET_FRAME_EXTENTS */
 	/* shared memory handling */
 	struct shm_cmd *shmcmd;	/* shared memory with Xorg */
@@ -376,6 +377,7 @@ static Window mkwindow(Ghandles * g, struct windowdata *vm_window)
 	Window parent;
 	XSizeHints my_size_hints;	/* hints for the window manager */
 	Atom atom_label;
+	int user_time = 0;
 
 	my_size_hints.flags = PSize;
 	my_size_hints.width = vm_window->width;
@@ -440,6 +442,12 @@ static Window mkwindow(Ghandles * g, struct windowdata *vm_window)
 			(const unsigned char *)&vm_window->remote_winid,
 			1);
 
+	// prevent focus stealing
+	XChangeProperty(g->display, child_win, g->wm_user_time, XA_CARDINAL,
+			32, PropModeReplace,
+			(const unsigned char *)&user_time,
+			1);
+
 	if (vm_window->remote_winid == FULLSCREEN_WINDOW_ID) {
 		/* whole screen window */
 		g->screen_window = vm_window;
@@ -489,6 +497,7 @@ static void mkghandles(Ghandles * g)
 	g->wm_state_fullscreen = XInternAtom(g->display, "_NET_WM_STATE_FULLSCREEN", False);
 	g->wm_state_demands_attention = XInternAtom(g->display, "_NET_WM_STATE_DEMANDS_ATTENTION", False);
 	g->wm_state_hidden = XInternAtom(g->display, "_NET_WM_STATE_HIDDEN", False);
+	g->wm_user_time = XInternAtom(g->display, "_NET_WM_USER_TIME", False);
 	g->frame_extents = XInternAtom(g->display, "_NET_FRAME_EXTENTS", False);
 	/* create graphical contexts */
 	get_frame_gc(g, g->cmdline_color ? : "red");

--- a/gui-daemon/xside.c
+++ b/gui-daemon/xside.c
@@ -1745,6 +1745,10 @@ static int send_set_monitor_layout(Ghandles* g)
 	char domid_str[16];
 	char* args[] = {"qrexec-client", "-d", domid_str, "DEFAULT:QUBESRPC qubes.SetMonitorLayout dom0", 0};
 
+	// HACK: the qrexec-client process seems to hang for HVMs, just skip it for now
+	if(g->qrexec_clipboard)
+		return 1;
+
 	snprintf(domid_str, sizeof(domid_str), "%d", g->target_domid);
 
 	fprintf(stderr, "send_set_monitor_layout %s", g->remote_monitor_layout);

--- a/screen-layout-handler/monitorlayoutnotify.py
+++ b/screen-layout-handler/monitorlayoutnotify.py
@@ -21,105 +21,15 @@
 #
 #
 
-from __future__ import absolute_import
-import re
-import sys
-from subprocess import Popen, PIPE, check_call
-from qubes.qubes import QubesVmCollection
-
-# "LVDS connected 1024x768+0+0 (normal left inverted right) 304mm x 228mm"
-REGEX_OUTPUT = re.compile(r"""
-        (?x)                           # ignore whitespace
-        ^                              # start of string
-        (?P<output>[A-Za-z0-9\-]*)[ ]  # LVDS VGA etc
-        (?P<connect>(dis)?connected)[ ]# dis/connected
-        (?P<primary>(primary)?)[ ]?
-        ((                             # a group
-           (?P<width>\d+)x             # either 1024x768+0+0
-           (?P<height>\d+)[+]  
-           (?P<x>\d+)[+]
-           (?P<y>\d+)
-         )|[\D])                       # or not a digit
-        .*                             # ignore rest of line
-        """)
-
+# Do nothing, guid itself now manages monitor layout notification
 def get_monitor_layout():
-    outputs = []
-
-    for line in Popen(['xrandr', '-q'], stdout=PIPE).stdout:
-        if not line.startswith("Screen") and not line.startswith(" "):
-            output_params = REGEX_OUTPUT.match(line).groupdict()
-            if output_params['width']:
-                outputs.append("%s %s %s %s\n" % (
-                            output_params['width'],
-                            output_params['height'],
-                            output_params['x'],
-                            output_params['y']))
-    return outputs
+    return ""
 
 def notify_vm(vm, monitor_layout):
-    pipe = vm.run("QUBESRPC qubes.SetMonitorLayout dom0", passio_popen=True, wait=True)
-
-    pipe.stdin.write(''.join(monitor_layout))
-    pipe.stdin.close()
-    return pipe
-
-def notify_vm_by_name(vmname):
-    monitor_layout = get_monitor_layout()
-
-    if len(monitor_layout) == 0:
-        return
-
-    qc = QubesVmCollection()
-    qc.lock_db_for_reading()
-    qc.load()
-    qc.unlock_db()
-
-    vm = qc.get_vm_by_name(vmname)
-    if not vm:
-        print >>sys.stderr, "No such VM!"
-        return 1
-    if not vm.is_running():
-        print >>sys.stderr, "VM not running!"
-        return 1
-    pipe = notify_vm(vm, monitor_layout)
-    pipe.wait()
-
-    return 0
-
-def notify_vms():
-
-    monitor_layout = get_monitor_layout()
-
-    if len(monitor_layout) == 0:
-        return
-
-    qc = QubesVmCollection()
-    qc.lock_db_for_reading()
-    qc.load()
-    qc.unlock_db()
-
-    pipes = []
-    for vm in qc.values():
-        if vm.qid == 0:
-            continue
-        if vm.is_running():
-            pipes.append(notify_vm(vm, monitor_layout))
-
-    for p in pipes:
-        p.wait()
-
-def reload_guid():
-    check_call(["killall", "-HUP", "qubes-guid"])
-                
+    return None
 
 def main():
-    if len(sys.argv) > 1:
-        """send monitor layout only to named VM"""
-        exit(notify_vm_by_name(sys.argv[1]))
-    else:
-        reload_guid()
-        notify_vms()
+    pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Introduction and rationale

This pull request seeks to change Qubes so that there is a new "private mode" in GUI daemon that no longer reveals the monitor size and configuration, the position of top-level windows to VMs and the position of the mouse pointer when outside VM windows.

Also it tries to make sure that VMs do not steal the input focus and cannot steal clicks by spawning new windows under the mouse pointer.

The rationale is to avoid exposing this data over the network when running ill-conceived software such as current non-Tor Browser JavaScript browsers that expose the screen size, avoid exposing it to exploited VMs that don't alter the GUI and also try to not reveal the information against exploited VMs that actively change the GUI (not sure if this last goal is fully achieved yet).

# Status and future work needed

It tries to minimize behavioral changes and should generally not be problematic, although for full privacy it would be necessary to disable mouse motion events, which is easy but this pull request doesn't do and that would need to be optional since it significantly degrades the user experience.

At the moment the private mode is not enabled for HVMs because the Windows tools seem to just copy parts of the screen rather than giving each window a separate buffer, which is required for this feature. It should be possible to do this on Vista+ by behaving like the Desktop Window Manager (DWM.exe) although that might require some reverse engineering of private Windows APIs.

We also need to have better anti-spoofing checks. The current code to clip override-redirect windows to the screen has been removed since reveals the screen size and didn't seem to prevent all cases of spoofing, and it would be better to instead draw the colored border around the visible part of the window instead of clipping it, but no complete replacement has been added (although the mouse pointer avoidance makes it harder to spoof the whole screen).

# The commit series

Unfortunately it turned out that this task was harder than expected, and required nontrivial changes to gui-daemon. I think this change can only be merged at the start of a development cycle and would require splitting at least the rework commit into smaller commits and justifying all the changes. I haven't done this yet due to lack of time and to avoid doing unnecessary work in case the whole approach is rejected.

It also needs to get a well specified threat model and some auditing to make sure that there are no attacks possible relative to the threat model. Some analysis of race conditions due to X and the GUI protocol being asynchronous should be done too.

The first commit removes the dom0 part of the current monitor layout notification system and moves it inside gui-daemon using Xrandr to listen for screen changes and sending notification by spawning qrexec. This is pretty straightforward and easy to merge (with perhaps minor fixing).

Another major commit is a rework of GUI daemon, which contains several miscellaneous changes, and is the most problematic one since it includes a bunch of unrelated and complex changes.

Then there is the commit that enables private mode, and mostly consists of new lines of code.

Finally there are few small commits that were easily split.

# Details

## Monitor size

To keep the monitor size private, we set (when private mode is on) the VM monitor size according to the size of its windows. In particular, we set it to smallest resolution that allows to fit all windows when they are all placed at (0, 24) from a list of 1366x768, 1920x1080, 3840x2160 and then resolutions that are multiples of 1920x1080.

We also resize all new windows to be smaller than the current monitor size to prevent the VM from causing a monitor resize by itself.

## The popup menu positioning issue

The major problem of this is that the VM no longer knows where the screen ends, which means that it will spawn popup menus that go offscreen.

To fix this, we need to move the popups. However, we can't move them depending on whether they are offscreen because that reveals the screen size, since the application can tell if they were moved based on the where the mouse pointer first enters the popups.

So instead we move popups so they are always contained in the application window, and try to align them properly with the parent menu if it's a submenu and otherwise with the mouse pointer. This changes behavior, but in practice it seems to work well.

However, we can't do this if the popup doesn't fit. In that case, we just don't move it and let the user move the parent window if it goes offscreen. This is also a change, but usually not an issue because it only happens for small parent windows, and small parent windows are rarely near the screen edge.

However, if we let a VM spawn such popups, it may be able to spawn popups under the mouse pointer, which would reveal a lower bound for the screen size. So, we move such popups to avoid the mouse pointer unless the mouse pointer is inside the parent window.

## Popup menus from docked windows

Docked windows spawn popup menus, and the popups obviously don't fit in the docked icons and also the icons cannot be moved, which defeats the previously described popup strategy.

So as a special exception we move popups from docked windows based on whether they are offscreen. We only do this if the mouse pointer is inside the docked icon and we avoid the icon itself.

Note that moving the mouse straight into the popup reveals to the VM where the system tray is located relative to the screen: this seems to be an unfixable issue without significant user experience degradation.

It's possible to fix this by either disabling mouse motion events, warping the mouse pointer or extending the virtual screen so that the user can access the offscreen part of the menu, but none of these are implemented and they all have problems.

## Keeping window positions private

We do it by simply telling the VM that the windows are where it placed them even if we or the user moved them elsewhere, with the exception that we move top-level windows to (0, 24) to simulate a window manager adding a titlebar and to avoid overlap with docked tray icons at (0, 0).

The problem is that as described above, programs often display windows without a parent but that need to be positioned relative to another window, such as popup menus.

To make things work correctly, we need to detect which window they intended the position to be relative to, and then translate between screens keeping that window fixed. If WM_TRANSIENT_FOR is set, we use that as the reference window, otherwise for override-redirect windows we use the last input window, and we record that until the window is unmapped.

We then look for a window to clip the window for by going up parents, transients and recorded reference windows that fully contain the previous window (see the code for details), and apply the positioning algorithm described before

## Top-level windows

For top-level windows, we place them at the center of the screen, and if they overlap the mouse pointer we dodge the pointer by trying to move the window down, left or right (not up because that tends to hide the title bar).

We could let the window manager do this, but it would require to add mouse pointer avoidance to all window managers.
